### PR TITLE
Upgrade Algolia and Alfred PHP Workflow dependencies to resolve errors on PHP 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor
+.vscode
 .DS_Store
+.phpunit.result.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Aflred workflow for quickly searching the php.net documentation.",
     "license": "MIT",
     "require": {
-        "algolia/algoliasearch-client-php": "^1.27",
+        "algolia/algoliasearch-client-php": "^3.3",
         "joetannenbaum/alfred-workflow": "^0.1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "Aflred workflow for quickly searching the php.net documentation.",
     "license": "MIT",
     "require": {
+        "php": "^7.4 | ^8.0",
         "algolia/algoliasearch-client-php": "^3.3",
-        "joetannenbaum/alfred-workflow": "^0.1.1",
-        "php": "^7.4 | ^8.0"
+        "joetannenbaum/alfred-workflow": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "require": {
         "algolia/algoliasearch-client-php": "^3.3",
-        "joetannenbaum/alfred-workflow": "^0.1.1"
+        "joetannenbaum/alfred-workflow": "^0.1.1",
+        "php": "^7.4 | ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/php-search.php
+++ b/php-search.php
@@ -7,6 +7,3 @@ $query = $argv[1] ?? '';
 $search = new \BillClark\PhpDocSearch\Search();
 
 echo $search->search($query);
-
-
-

--- a/php-search.php
+++ b/php-search.php
@@ -2,7 +2,7 @@
 
 require __DIR__ . '/vendor/autoload.php';
 
-$query = $argv[1];
+$query = $argv[1] ?? '';
 
 $search = new \BillClark\PhpDocSearch\Search();
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -34,11 +34,15 @@ class Search
     }
 
     /**
-     * @param $query
-     * @return string
-     * @throws \AlgoliaSearch\AlgoliaException
+     * Execute a search against the Algolia index.
+     *
+     * @param string $query The search query.
+     *
+     * @return string A JSON-encoded set of results.
+     *
+     * @throws \Algolia\AlgoliaSearch\Exceptions\AlgoliaException
      */
-    public function search($query)
+    public function search(string $query): string
     {
         $search = $this->index->search($query);
 
@@ -60,16 +64,5 @@ class Search
         }
 
         return $this->workflow->output();
-    }
-
-    /**
-     * @param $data
-     * @return mixed
-     */
-    public function getTitle($data)
-    {
-        $parsedData = json_decode($data);
-
-        return $parsedData->items[0]->title;
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -3,7 +3,7 @@
 namespace BillClark\PhpDocSearch;
 
 use Alfred\Workflows\Workflow;
-use AlgoliaSearch\Client as Algolia;
+use Algolia\AlgoliaSearch\SearchClient;
 
 class Search
 {
@@ -24,7 +24,7 @@ class Search
     public function __construct()
     {
         $this->workflow = new Workflow();
-        $this->algoliaClient = new Algolia('A6XQ78SBYL', '6b55caa922558f0094b3aba94b293d0c');
+        $this->algoliaClient = SearchClient::create('A6XQ78SBYL', '6b55caa922558f0094b3aba94b293d0c');
         $this->index = $this->algoliaClient->initIndex('php-docs');
     }
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -9,9 +9,9 @@ use Algolia\AlgoliaSearch\SearchIndex;
 class Search
 {
     /**
-     * @var Workflow
+     * The Alfred PHP Workflow instance.
      */
-    private $workflow;
+    private Workflow $workflow;
 
     /**
      * The Algolia search client.
@@ -46,23 +46,23 @@ class Search
     {
         $search = $this->index->search($query);
 
-        $results = $search['hits'];
+        $results = $search['hits'] ?? [];
 
         foreach ($results as $hit) {
             $title = strip_tags(html_entity_decode($hit['_highlightResult']['title']['value'], ENT_QUOTES, 'UTF-8'));
 
             $link = preg_replace('/en/', $_ENV['language'] ?? 'en', $hit['link']);
 
-            $this->workflow->result()
+            $this->workflow->item()
                 ->uid($hit['objectID'])
                 ->title($title)
                 ->autocomplete($title)
                 ->subtitle($hit['subtext'])
                 ->arg($link)
-                ->quicklookurl($link)
+                ->quickLookUrl($link)
                 ->valid(true);
         }
 
-        return $this->workflow->output();
+        return $this->workflow->output(false);
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -4,6 +4,7 @@ namespace BillClark\PhpDocSearch;
 
 use Alfred\Workflows\Workflow;
 use Algolia\AlgoliaSearch\SearchClient;
+use Algolia\AlgoliaSearch\SearchIndex;
 
 class Search
 {
@@ -13,13 +14,17 @@ class Search
     private $workflow;
 
     /**
-     * @var Algolia
+     * The Algolia search client.
      */
-    private $algoliaClient;
+    private SearchClient $algoliaClient;
+
+    /**
+     * The Algolia search index.
+     */
+    private SearchIndex $index;
 
     /**
      * Search constructor.
-     * @throws \AlgoliaSearch\AlgoliaException
      */
     public function __construct()
     {

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -1,18 +1,62 @@
 <?php
 
+use BillClark\PhpDocSearch\Search;
 use PHPUnit\Framework\TestCase;
 
-use BillClark\PhpDocSearch\Search;
-
+/**
+ * Please be aware that these tests hit the Algolia service directly, so internet connectivity
+ * is required!
+ */
 class SearchTest extends TestCase
 {
-    /** @test */
-    public function a_query_returns_correct_result()
+    /**
+     * @test
+     */
+    public function a_query_returns_correct_result(): void
     {
-        $phpDocSearch = new Search();
+        $search = new Search();
+        $results = $search->search('parsekit_compile_string');
+        $titles = $this->extractTitles($results);
 
-        $algoliaData = $phpDocSearch->search('parsekit_compile_string');
+        $this->assertCount(1, $titles, 'Expected to only find one match.');
+        $this->assertSame('parsekit_compile_string', current($titles));
+    }
 
-        $this->assertEquals($phpDocSearch->getTitle($algoliaData), 'parsekit_compile_string');
+    /**
+     * @test
+     */
+    public function a_query_can_return_multiple_matches(): void
+    {
+        $search = new Search();
+        $results = $search->search('date');
+        $titles = $this->extractTitles($results);
+
+        $this->assertGreaterThan(1, $titles, 'Expected to find multiple matches.');
+        $this->assertContains('date', $titles, 'The exact match should be present.');
+
+        // Verify that every result includes "date".
+        array_walk($titles, fn ($title) => $this->assertStringContainsString('date', $title));
+    }
+
+    /**
+     * Extract an array of search result titles.
+     *
+     * @param string $results The JSON-encoded results.
+     *
+     * @return array<string> An array consisting of only the results' titles.
+     */
+    private function extractTitles(string $results): array
+    {
+        $data = json_decode($results);
+
+        if (! isset($data->items)) {
+            throw new \RuntimeException('Unable to parse JSON structure.');
+        }
+
+        return array_reduce($data->items, function ($titles, $result) {
+            $titles[] = $result->title;
+
+            return $titles;
+        }, []);
     }
 }


### PR DESCRIPTION
When running this workflow on systems running newer versions of PHP, the workflow silently fails due to deprecation warnings breaking the parsing of JSON output.

Results from running the workflow with Alfred debugging enabled:

```none
[14:31:11.370] PHP Docs[Script Filter] Queuing argument 'i'
[14:31:11.434] PHP Docs[Script Filter] Queuing argument 'is'
[14:31:11.623] PHP Docs[Script Filter] Script with argv '(null)' finished
[14:31:11.627] STDERR: PHP Docs[Script Filter] PHP Deprecated:  Creation of dynamic property AlgoliaSearch\ClientContext::$readTimeout is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 99
PHP Deprecated:  Creation of dynamic property AlgoliaSearch\ClientContext::$searchTimeout is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 102
PHP Deprecated:  Creation of dynamic property AlgoliaSearch\ClientContext::$rateLimitAPIKey is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 127
PHP Deprecated:  Creation of dynamic property AlgoliaSearch\ClientContext::$headers is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 128
PHP Deprecated:  Creation of dynamic property BillClark\PhpDocSearch\Search::$index is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/src/Search.php on line 28
[14:31:11.629] PHP Docs[Script Filter] Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$readTimeout is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 99

Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$searchTimeout is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 102

Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$rateLimitAPIKey is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 127

Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$headers is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 128

Deprecated: Creation of dynamic property BillClark\PhpDocSearch\Search::$index is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/src/Search.php on line 28
{"items":[{"arg":"http:\/\/php.net\/manual\/en\/function.iterator-to-array.php","autocomplete":"iterator_to_array","quicklookurl":"http:\/\/php.net\/manual\/en\/function.iterator-to-array.php","subtitle":"Copy the iterator into an array","title":"iterator_to_array","uid":"5366281","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.iterator-count.php","autocomplete":"iterator_count","quicklookurl":"http:\/\/php.net\/manual\/en\/function.iterator-count.php","subtitle":"Count the elements in an iterator","title":"iterator_count","uid":"5366271","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.iterator-apply.php","autocomplete":"iterator_apply","quicklookurl":"http:\/\/php.net\/manual\/en\/function.iterator-apply.php","subtitle":"Call a function for every element in an iterator","title":"iterator_apply","uid":"5366261","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.construct.php","autocomplete":"IteratorIterator::__construct","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.construct.php","subtitle":"Create an iterator from anything that is traversable","title":"IteratorIterator::__construct","uid":"5366251","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.valid.php","autocomplete":"IteratorIterator::valid","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.valid.php","subtitle":"Checks if the iterator is valid","title":"IteratorIterator::valid","uid":"5366241","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.rewind.php","autocomplete":"IteratorIterator::rewind","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.rewind.php","subtitle":"Rewind to the first element","title":"IteratorIterator::rewind","uid":"5366231","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.next.php","autocomplete":"IteratorIterator::next","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.next.php","subtitle":"Forward to the next element","title":"IteratorIterator::next","uid":"5366221","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.key.php","autocomplete":"IteratorIterator::key","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.key.php","subtitle":"Get the key of the current element","title":"IteratorIterator::key","uid":"5366211","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.getinneriterator.php","autocomplete":"IteratorIterator::getInnerIterator","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.getinneriterator.php","subtitle":"Get the inner iterator","title":"IteratorIterator::getInnerIterator","uid":"5366201","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.current.php","autocomplete":"IteratorIterator::current","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.current.php","subtitle":"Get the current value","title":"IteratorIterator::current","uid":"5366191","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoraggregate.getiterator.php","autocomplete":"IteratorAggregate::getIterator","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoraggregate.getiterator.php","subtitle":"Retrieve an external iterator","title":"IteratorAggregate::getIterator","uid":"5366181","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.valid.php","autocomplete":"Iterator::valid","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.valid.php","subtitle":"Checks if current position is valid","title":"Iterator::valid","uid":"5366171","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.rewind.php","autocomplete":"Iterator::rewind","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.rewind.php","subtitle":"Rewind the Iterator to the first element","title":"Iterator::rewind","uid":"5366161","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.next.php","autocomplete":"Iterator::next","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.next.php","subtitle":"Move forward to next element","title":"Iterator::next","uid":"5366151","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.key.php","autocomplete":"Iterator::key","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.key.php","subtitle":"Return the key of the current element","title":"Iterator::key","uid":"5366141","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.current.php","autocomplete":"Iterator::current","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.current.php","subtitle":"Return the current element","title":"Iterator::current","uid":"5366131","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-writeable.php","autocomplete":"is_writeable","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-writeable.php","subtitle":"Alias of is_writable","title":"is_writeable","uid":"5366121","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-writable.php","autocomplete":"is_writable","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-writable.php","subtitle":"Tells whether the filename is writable","title":"is_writable","uid":"5366111","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-uploaded-file.php","autocomplete":"is_uploaded_file","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-uploaded-file.php","subtitle":"Tells whether the file was uploaded via HTTP POST","title":"is_uploaded_file","uid":"5366101","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-tainted.php","autocomplete":"is_tainted","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-tainted.php","subtitle":"Checks whether a string is tainted","title":"is_tainted","uid":"5366091","valid":true}]}
[14:31:11.636] ERROR: PHP Docs[Script Filter] JSON error: JSON text did not start with array or object and option to allow fragments not set. in JSON:
Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$readTimeout is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 99

Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$searchTimeout is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 102

Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$rateLimitAPIKey is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 127

Deprecated: Creation of dynamic property AlgoliaSearch\ClientContext::$headers is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/vendor/algolia/algoliasearch-client-php/src/AlgoliaSearch/ClientContext.php on line 128

Deprecated: Creation of dynamic property BillClark\PhpDocSearch\Search::$index is deprecated in /Users/steve/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.0DA0E004-BCB7-407A-8938-A03D9F1C11E6/src/Search.php on line 28
{"items":[{"arg":"http:\/\/php.net\/manual\/en\/function.iterator-to-array.php","autocomplete":"iterator_to_array","quicklookurl":"http:\/\/php.net\/manual\/en\/function.iterator-to-array.php","subtitle":"Copy the iterator into an array","title":"iterator_to_array","uid":"5366281","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.iterator-count.php","autocomplete":"iterator_count","quicklookurl":"http:\/\/php.net\/manual\/en\/function.iterator-count.php","subtitle":"Count the elements in an iterator","title":"iterator_count","uid":"5366271","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.iterator-apply.php","autocomplete":"iterator_apply","quicklookurl":"http:\/\/php.net\/manual\/en\/function.iterator-apply.php","subtitle":"Call a function for every element in an iterator","title":"iterator_apply","uid":"5366261","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.construct.php","autocomplete":"IteratorIterator::__construct","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.construct.php","subtitle":"Create an iterator from anything that is traversable","title":"IteratorIterator::__construct","uid":"5366251","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.valid.php","autocomplete":"IteratorIterator::valid","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.valid.php","subtitle":"Checks if the iterator is valid","title":"IteratorIterator::valid","uid":"5366241","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.rewind.php","autocomplete":"IteratorIterator::rewind","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.rewind.php","subtitle":"Rewind to the first element","title":"IteratorIterator::rewind","uid":"5366231","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.next.php","autocomplete":"IteratorIterator::next","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.next.php","subtitle":"Forward to the next element","title":"IteratorIterator::next","uid":"5366221","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.key.php","autocomplete":"IteratorIterator::key","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.key.php","subtitle":"Get the key of the current element","title":"IteratorIterator::key","uid":"5366211","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.getinneriterator.php","autocomplete":"IteratorIterator::getInnerIterator","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.getinneriterator.php","subtitle":"Get the inner iterator","title":"IteratorIterator::getInnerIterator","uid":"5366201","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoriterator.current.php","autocomplete":"IteratorIterator::current","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoriterator.current.php","subtitle":"Get the current value","title":"IteratorIterator::current","uid":"5366191","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iteratoraggregate.getiterator.php","autocomplete":"IteratorAggregate::getIterator","quicklookurl":"http:\/\/php.net\/manual\/en\/iteratoraggregate.getiterator.php","subtitle":"Retrieve an external iterator","title":"IteratorAggregate::getIterator","uid":"5366181","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.valid.php","autocomplete":"Iterator::valid","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.valid.php","subtitle":"Checks if current position is valid","title":"Iterator::valid","uid":"5366171","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.rewind.php","autocomplete":"Iterator::rewind","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.rewind.php","subtitle":"Rewind the Iterator to the first element","title":"Iterator::rewind","uid":"5366161","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.next.php","autocomplete":"Iterator::next","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.next.php","subtitle":"Move forward to next element","title":"Iterator::next","uid":"5366151","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.key.php","autocomplete":"Iterator::key","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.key.php","subtitle":"Return the key of the current element","title":"Iterator::key","uid":"5366141","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/iterator.current.php","autocomplete":"Iterator::current","quicklookurl":"http:\/\/php.net\/manual\/en\/iterator.current.php","subtitle":"Return the current element","title":"Iterator::current","uid":"5366131","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-writeable.php","autocomplete":"is_writeable","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-writeable.php","subtitle":"Alias of is_writable","title":"is_writeable","uid":"5366121","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-writable.php","autocomplete":"is_writable","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-writable.php","subtitle":"Tells whether the filename is writable","title":"is_writable","uid":"5366111","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-uploaded-file.php","autocomplete":"is_uploaded_file","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-uploaded-file.php","subtitle":"Tells whether the file was uploaded via HTTP POST","title":"is_uploaded_file","uid":"5366101","valid":true},{"arg":"http:\/\/php.net\/manual\/en\/function.is-tainted.php","autocomplete":"is_tainted","quicklookurl":"http:\/\/php.net\/manual\/en\/function.is-tainted.php","subtitle":"Checks whether a string is tainted","title":"is_tainted","uid":"5366091","valid":true}]}
```

[PHP 8.2 deprecated dynamic properties](https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.dynamic-properties), but both `BillClark\PhpDocSearch\Search` and `AlgoliaSearch\ClientContext` had some missing property declarations. The resulting deprecation warning from PHP caused additional output to STDOUT, which prevented Alfred from parsing the JSON containing the search results.

This PR does the following:

1. Upgrade the non-dev dependencies (Algolia, Alfred PHP Workflow) to their latest versions
    * This comes with it a minimum PHP version of 7.4, which has [already reached End-of Life status](https://www.php.net/supported-versions.php) but is unfortunately still widely used
2. Explicitly define the missing `BillClark\PhpDocSearch\Search::$index` property
3. Remove `Search::getTitle()`, which was only being used in the test suite. Instead, define `SearchTest::extractTitles()`.
4. With the bump in minimum PHP version, take advantage of newer language features (stronger typing, arrow functions, null coalesce, etc.)

I've duplicated the workflow locally to test and everything is working again 😄 

Thank you for this workflow, it's one I find myself using multiple times daily!